### PR TITLE
:sparkles: loggerモジュールを追加

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,73 @@
+import logging
+import inspect
+import os
+
+
+class Logger():
+    """log出力に関するクラス
+
+    クラス作成時に出力したいログレベルが指定されていればそれを
+    指定されなければ環境変数から取得したログレベルを出力する
+    """
+
+    def __init__(self, streamLevel=None):
+        self.__streamLogger = logging.getLogger()
+        for handler in self.__streamLogger.handlers:
+            self.__streamLogger.removeHandler(handler)
+        self.formatter = logging.Formatter(
+            '{"time":"%(asctime)s","level":"%(levelname)s",%(message)s"}')
+        self.__streamHandler = logging.StreamHandler()
+        self.__streamHandler.setFormatter(self.formatter)
+        self.__streamLogger.addHandler(self.__streamHandler)
+
+        if streamLevel is not None:
+            self.__streamLogger.setLevel(streamLevel)
+        else:
+            self._setLogLevelFromEnv()
+
+    def _setLogLevelFromEnv(self):
+        logLevel = os.getenv('LOGLEVEL')
+        if logLevel == 'DEBUG':
+            self.__streamLogger.setLevel(logging.DEBUG)
+        elif logLevel == 'INFO':
+            self.__streamLogger.setLevel(logging.INFO)
+        elif logLevel == 'WARNING':
+            self.__streamLogger.setLevel(logging.WARNING)
+        elif logLevel == 'ERROR':
+            self.__streamLogger.setLevel(logging.ERROR)
+        else:
+            # 環境変数から見つからない場合のデフォルトはINFOで
+            self.__streamLogger.setLevel(logging.INFO)
+
+
+    def _getLocation(self):
+        frame = inspect.currentframe().f_back.f_back
+        filename = os.path.basename(frame.f_code.co_filename)
+        return '{}, {}, {}'.format(filename, frame.f_code.co_name, frame.f_lineno)
+
+    def writeLogDebug(self, message):
+        self._writeLog('DEBUG', message, str(self._getLocation()))
+
+    def writeLogInfo(self, message):
+        self._writeLog('INFO', message, str(self._getLocation()))
+
+    def writeLogWarning(self, message):
+        self._writeLog('WARNING', message, str(self._getLocation()))
+
+    def writeLogError(self, message):
+        self._writeLog('ERROR', message, str(self._getLocation()))
+
+    def _writeLog(self, logLevel, message, location=None):
+        if location is None:
+            location = str(self._getLocation())
+
+        message ='"location":"' + location + '",' + '"message":"' + str(message)
+
+        if logLevel == 'DEBUG':
+            self.__streamLogger.debug(message)
+        elif logLevel == 'INFO':
+            self.__streamLogger.info(message)
+        elif logLevel == 'WARNING':
+            self.__streamLogger.warning(message)
+        elif logLevel == 'ERROR':
+            self.__streamLogger.error(message)


### PR DESCRIPTION
## はじめに
logger.pyを追加しただけです \
使い方を参考にして使ってみてください

## 使い方

使いたい場所でimportしたあと、吐き出したいログレベルの関数を使う
```
from logger import Logger

logger = Logger()
logger.writeLogDebug('これはDebugLogです')
logger.writeLogInfo('これはInfoLogです')
logger.writeLogWarning('これはWaringLogです')
logger.writeLogError('これはErrorLogです')
```

実行結果(例)
```
{"time":"2024-03-07 22:17:51,828","level":"DEBUG","location":"main.py, <module>, 186","message":"これはDebugLogです"}
{"time":"2024-03-07 22:17:51,828","level":"INFO","location":"main.py, <module>, 187","message":"これはInfoLogです"}
{"time":"2024-03-07 22:17:51,829","level":"WARNING","location":"main.py, <module>, 188","message":"これはWaringLogです"}
{"time":"2024-03-07 22:17:51,829","level":"ERROR","location":"main.py, <module>, 189","message":"これはErrorLogです"}
```

どのログレベルまで出力されるかの制御は \
・Logger作成時に指定する方法
```
logger = Logger(logging.INFO)
```

・環境変数から読み込む方法 \
(環境変数から"LOGLEVEL"に書かれている文字列を読み取り設定、見つからない場合はINFO) \
 \
がある(開発環境、本番環境が分かれている場合は環境変数に書いておくと楽) \
が、しばらく出力レベルの制御をする必要がない場合は
```
self.__streamLogger.setLevel(<セットしたい出力レベル>)
```
を__init__()内に直接書いてもいいかも

## さいごに
すぐにloggerを導入しないとは思いますが、もし使いづらいとかこうなっててほしいとかあれば言ってください \
使う人のフィードバックは大切だとルリ思う故にルリあり
