### PR TITLE
logger.pyにファイル出力機能を追加

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -46,16 +46,16 @@ class Logger():
         return '{}, {}, {}'.format(filename, frame.f_code.co_name, frame.f_lineno)
 
     def writeLogDebug(self, message):
-        self._writeLog('DEBUG', message, str(self._getLocation()))
+        self._writeLog(logging.DEBUG, message, str(self._getLocation()))
 
     def writeLogInfo(self, message):
-        self._writeLog('INFO', message, str(self._getLocation()))
+        self._writeLog(logging.INFO, message, str(self._getLocation()))
 
     def writeLogWarning(self, message):
-        self._writeLog('WARNING', message, str(self._getLocation()))
+        self._writeLog(logging.WARNING, message, str(self._getLocation()))
 
     def writeLogError(self, message):
-        self._writeLog('ERROR', message, str(self._getLocation()))
+        self._writeLog(logging.ERROR, message, str(self._getLocation()))
 
     def _writeLog(self, logLevel, message, location=None):
         if location is None:
@@ -63,11 +63,11 @@ class Logger():
 
         message ='"location":"' + location + '",' + '"message":"' + str(message)
 
-        if logLevel == 'DEBUG':
+        if logLevel == logging.DEBUG:
             self.__streamLogger.debug(message)
-        elif logLevel == 'INFO':
+        elif logLevel == logging.INFO:
             self.__streamLogger.info(message)
-        elif logLevel == 'WARNING':
+        elif logLevel == logging.WARNING:
             self.__streamLogger.warning(message)
-        elif logLevel == 'ERROR':
+        elif logLevel == logging.ERROR:
             self.__streamLogger.error(message)


### PR DESCRIPTION
## はじめに
logger.pyにファイル出力機能を追加しました

## 使い方
使いたい場所でimportしたあと、吐き出したいログレベルの関数を使う \
このときoutputFileをTrueにするとログがファイルにも出力される \
Falseの場合はストリームにだけ出力される(今までと同じ)
```
from logger import Logger

logger = Logger(outputFile=True)
logger.writeLogDebug('これはDebugLogです')
logger.writeLogInfo('これはInfoLogです')
logger.writeLogWarning('これはWaringLogです')
logger.writeLogError('これはErrorLogです')
```

実行結果(例) \
これが初期設定だと「./log.log」にも同じように出力される
```
{"time":"2024-03-07 22:17:51,828","level":"DEBUG","location":"main.py, <module>, 186","message":"これはDebugLogです"}
{"time":"2024-03-07 22:17:51,828","level":"INFO","location":"main.py, <module>, 187","message":"これはInfoLogです"}
{"time":"2024-03-07 22:17:51,829","level":"WARNING","location":"main.py, <module>, 188","message":"これはWaringLogです"}
{"time":"2024-03-07 22:17:51,829","level":"ERROR","location":"main.py, <module>, 189","message":"これはErrorLogです"}
```

## 最後に
詳細にログ出力の設定をするならlogging.config.dictConfig()なりlogging.config.FileConfig()なりで \
dictやファイル上に細かく定義を書いてそれを読み込んだほうがいいんだけどそこまではいらないかな？ \
ということで基本のStreamHandlerに必要に応じてRotatingFileHandlerを追加する方法にしました \
 \
ファイル出力の設定は頻繁にいじるような設定でもないのでクラスの外に定数定義としています \
理想は環境変数から読み込む方法かな…？