### PR TITLE
Fix test hellomeg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .env
+.coverage

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
         "*_test.py"
     ],
     "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.unittestEnabled": true,
+    "files.exclude": {
+        "**/__pycache__": true
+    }
 }

--- a/src/hellomegbot/commands/hellomeg.py
+++ b/src/hellomegbot/commands/hellomeg.py
@@ -114,7 +114,7 @@ def register_command(tree):
 def set_config(fever_minute=None, ur_prob=None, sr_prob=None):
     """設定値を更新する"""
     global hellomeg_fever_minute, hellomeg_ur_probability, hellomeg_sr_probability
-    
+
     if fever_minute is not None:
         hellomeg_fever_minute = fever_minute
     if ur_prob is not None:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

This pull request includes updates to testing configurations and test cases for the `hellomeg` bot, as well as a minor update to the `.vscode/settings.json` file. The changes focus on improving test stability, adding explicit configurations for FEVER mode, and excluding unnecessary files from the editor.

### Testing Improvements:

* Added explicit handling of the `fever_minute` parameter in test cases to ensure FEVER mode behavior is well-defined and does not interfere with test stability. This includes saving and restoring the original `fever_minute` value in multiple test functions. [[1]](diffhunk://#diff-bf467035a7a5471ea0df260cfcbcd79978d3b195bf29805061aa820e2e412d57R103-R152) [[2]](diffhunk://#diff-bf467035a7a5471ea0df260cfcbcd79978d3b195bf29805061aa820e2e412d57R161) [[3]](diffhunk://#diff-bf467035a7a5471ea0df260cfcbcd79978d3b195bf29805061aa820e2e412d57R170-R177) [[4]](diffhunk://#diff-bf467035a7a5471ea0df260cfcbcd79978d3b195bf29805061aa820e2e412d57L199-R238) [[5]](diffhunk://#diff-bf467035a7a5471ea0df260cfcbcd79978d3b195bf29805061aa820e2e412d57R286)

* Mocked additional components in `test_register_command_normal_response` to improve test isolation, including `random.random`, `random.uniform`, `random.choice`, and `discord.File`. This ensures that the test does not depend on external randomness or file operations.

* Removed the `test_setup_hellomeg_empty_dir` test case, which previously verified behavior when the directory was empty. This might indicate a change in requirements or a decision to deprecate this specific test.

### Configuration Updates:

* Updated `.vscode/settings.json` to exclude `__pycache__` directories from the editor view, reducing clutter in the development environment.

### Code Cleanup:

* Removed unused import of `os` and adjusted imports in `test_hellomeg.py` to streamline the file.

<!-- I want to review in Japanese. -->
