### PR TITLE
add gha

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,13 +5,24 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:  # 手動実行を可能にする
+    inputs:
+      python-version:
+        description: 'Python version to test (comma-separated for multiple, leave empty for all)'
+        required: false
+        default: ''
+      skip-coverage:
+        description: 'Skip coverage report generation (true/false)'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python-version != '' && fromJSON('[' + github.event.inputs.python-version + ']') || fromJSON('[3.8, 3.9, "3.10"]') }}
 
     steps:
     - uses: actions/checkout@v3
@@ -32,10 +43,12 @@ jobs:
         pytest tests/ -v
     
     - name: Generate coverage report
+      if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip-coverage != 'true' }}
       run: |
         pytest --cov=src/ tests/ --cov-report=xml
     
     - name: Upload coverage to Codecov
+      if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip-coverage != 'true' }}
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,7 +25,7 @@ jobs:
         # Determine the Python versions to test:
         # - If triggered by 'workflow_dispatch' and 'python-version' input is provided, parse the input as a JSON array.
         # - Otherwise, use the default Python versions [3.8, 3.9, "3.10"].
-        python-version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python-version != '' && fromJSON('[' + github.event.inputs.python-version + ']') || fromJSON('[3.8, 3.9, "3.10"]') }}
+        python-version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python-version != '' && fromJSON('[' + github.event.inputs.python-version + ']') || fromJSON('["3.8", "3.9", "3.10"]') }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,42 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, '3.10']
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+    
+    - name: Run tests
+      run: |
+        pytest tests/ -v
+    
+    - name: Generate coverage report
+      run: |
+        pytest --cov=src/ tests/ --cov-report=xml
+    
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # Determine the Python versions to test:
+        # - If triggered by 'workflow_dispatch' and 'python-version' input is provided, parse the input as a JSON array.
+        # - Otherwise, use the default Python versions [3.8, 3.9, "3.10"].
         python-version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python-version != '' && fromJSON('[' + github.event.inputs.python-version + ']') || fromJSON('[3.8, 3.9, "3.10"]') }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # hellomegbot
+![Python Tests](https://github.com/username/hellomegbot/actions/workflows/python-tests.yml/badge.svg)
 ### Usage
 1. 環境変数 `DISCORD_BOT_TOKEN` を設定
     ```bash
@@ -12,3 +13,23 @@
     ```bash
     python main.py
     ```
+
+### Development
+
+#### Setup Development Environment
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+#### Running Tests
+```bash
+# Run all tests
+pytest tests/
+
+# Run tests with coverage report
+pytest --cov=src/ tests/
+
+# Run specific test file
+pytest tests/unit/commands/test_hellomeg.py
+```

--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ pytest --cov=src/ tests/
 # Run specific test file
 pytest tests/unit/commands/test_hellomeg.py
 ```
+
+#### GitHub Actions
+
+このプロジェクトはGitHub Actionsを使用して自動テストを実行します。
+
+- プッシュやプルリクエスト時に自動的にテストが実行されます
+- GitHub UIから手動でテストを実行することも可能です:
+  1. リポジトリの "Actions" タブに移動
+  2. 左側のサイドバーから "Python Tests" ワークフローを選択
+  3. "Run workflow" ボタンをクリック
+  4. 以下のオプションを設定可能:
+     - `Python version`: テストするPythonバージョン（カンマ区切りで複数指定可能、例: `3.8,3.9`）
+     - `Skip coverage`: カバレッジレポート生成をスキップするかどうか
+  5. "Run workflow" をクリック


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

This pull request introduces a GitHub Actions workflow for running Python tests, updates the `README.md` to include a test status badge, and adds instructions for setting up a development environment and running tests. These changes aim to enhance the development process and provide better visibility into the project's test coverage.

### CI/CD Integration:
* [`.github/workflows/python-tests.yml`](diffhunk://#diff-207f09dfa0bc604a684631a1c78be7d9aa00f9a6c778eec30afa287990be3da1R1-R42): Added a GitHub Actions workflow to automate Python tests across multiple Python versions (3.8, 3.9, 3.10), generate a coverage report, and upload it to Codecov.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2): Added a Python Tests badge to display the status of the test workflow.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R35): Added a "Development" section with instructions for setting up the development environment, running tests, and generating test coverage reports.

<!-- I want to review in Japanese. -->
