### PR TITLE
fix gha

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,26 +6,13 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:  # 手動実行を可能にする
-    inputs:
-      python-version:
-        description: 'Python version to test (comma-separated for multiple, leave empty for all)'
-        required: false
-        default: ''
-      skip-coverage:
-        description: 'Skip coverage report generation (true/false)'
-        required: false
-        default: 'false'
-        type: boolean
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Determine the Python versions to test:
-        # - If triggered by 'workflow_dispatch' and 'python-version' input is provided, parse the input as a JSON array.
-        # - Otherwise, use the default Python versions [3.8, 3.9, "3.10"].
-        python-version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python-version != '' && fromJSON('[' + github.event.inputs.python-version + ']') || fromJSON('["3.8", "3.9", "3.10"]') }}
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v3
@@ -46,12 +33,10 @@ jobs:
         pytest tests/ -v
     
     - name: Generate coverage report
-      if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip-coverage != 'true' }}
       run: |
         pytest --cov=src/ tests/ --cov-report=xml
     
     - name: Upload coverage to Codecov
-      if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip-coverage != 'true' }}
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

This pull request simplifies the GitHub Actions workflow for Python tests by removing support for custom inputs during manual workflow dispatch and standardizing the Python version matrix. The most significant changes include the removal of user-defined inputs for Python versions and coverage options, as well as the simplification of conditional logic for coverage generation and upload.

### Workflow simplification:

* [`.github/workflows/python-tests.yml`](diffhunk://#diff-207f09dfa0bc604a684631a1c78be7d9aa00f9a6c778eec30afa287990be3da1L9-R15): Removed the `inputs` section under `workflow_dispatch`, which previously allowed users to specify custom Python versions and skip coverage reporting.
* [`.github/workflows/python-tests.yml`](diffhunk://#diff-207f09dfa0bc604a684631a1c78be7d9aa00f9a6c778eec30afa287990be3da1L9-R15): Standardized the Python version matrix to always use `[3.9]`, removing the dynamic logic for determining Python versions based on user input.

### Coverage logic simplification:

* [`.github/workflows/python-tests.yml`](diffhunk://#diff-207f09dfa0bc604a684631a1c78be7d9aa00f9a6c778eec30afa287990be3da1L49-L54): Removed conditional checks for skipping coverage generation and upload, as the `skip-coverage` input is no longer supported.

<!-- I want to review in Japanese. -->
