### PR TITLE
update gha

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,9 +2,9 @@ name: Python Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
   workflow_dispatch:  # 手動実行を可能にする
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hellomegbot
-![Python Tests](https://github.com/username/hellomegbot/actions/workflows/python-tests.yml/badge.svg)
+![Python Tests](https://github.com/mtsml/hellomegbot/actions/workflows/python-tests.yml/badge.svg)
 ### Usage
 1. 環境変数 `DISCORD_BOT_TOKEN` を設定
     ```bash


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

This pull request includes updates to the branch naming convention in the CI workflow configuration and a fix to the repository URL in the README badge.

### Workflow configuration updates:
* [`.github/workflows/python-tests.yml`](diffhunk://#diff-207f09dfa0bc604a684631a1c78be7d9aa00f9a6c778eec30afa287990be3da1L5-R7): Changed branch references from `main` to `master` for both `push` and `pull_request` events to align with the repository's branch naming convention.

### Documentation fix:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R2): Updated the badge URL to correctly point to the repository `mtsml/hellomegbot` instead of `username/hellomegbot`.

<!-- I want to review in Japanese. -->
